### PR TITLE
v2: Improve signature and nonce handling

### DIFF
--- a/mux.go
+++ b/mux.go
@@ -51,7 +51,7 @@ func (m *Mux) DialStream() *Stream {
 func Dial(conn net.Conn, theirKey ed25519.PublicKey) (*Mux, error) {
 	// exchange versions
 	var theirVersion [1]byte
-	if _, err := conn.Write([]byte{2}); err != nil {
+	if _, err := conn.Write([]byte{3}); err != nil {
 		return nil, fmt.Errorf("could not write our version: %w", err)
 	} else if _, err := io.ReadFull(conn, theirVersion[:]); err != nil {
 		return nil, fmt.Errorf("could not read peer version: %w", err)
@@ -62,7 +62,7 @@ func Dial(conn net.Conn, theirKey ed25519.PublicKey) (*Mux, error) {
 		m, err := muxv1.Dial(conn, theirKey)
 		return &Mux{m1: m}, err
 	}
-	m, err := muxv2.Dial(conn, theirKey)
+	m, err := muxv2.Dial(conn, theirKey, theirVersion[0])
 	return &Mux{m2: m}, err
 }
 
@@ -72,7 +72,7 @@ func Accept(conn net.Conn, ourKey ed25519.PrivateKey) (*Mux, error) {
 	var theirVersion [1]byte
 	if _, err := io.ReadFull(conn, theirVersion[:]); err != nil {
 		return nil, fmt.Errorf("could not read peer version: %w", err)
-	} else if _, err := conn.Write([]byte{2}); err != nil {
+	} else if _, err := conn.Write([]byte{3}); err != nil {
 		return nil, fmt.Errorf("could not write our version: %w", err)
 	} else if theirVersion[0] == 0 {
 		return nil, errors.New("peer sent invalid version")
@@ -81,7 +81,7 @@ func Accept(conn net.Conn, ourKey ed25519.PrivateKey) (*Mux, error) {
 		m, err := muxv1.Accept(conn, ourKey)
 		return &Mux{m1: m}, err
 	}
-	m, err := muxv2.Accept(conn, ourKey)
+	m, err := muxv2.Accept(conn, ourKey, theirVersion[0])
 	return &Mux{m2: m}, err
 }
 

--- a/spec_v2.md
+++ b/spec_v2.md
@@ -33,18 +33,18 @@ The *dialing peer* generates an X25519 keypair and sends:
 
 | Length | Type   | Description   |
 |--------|--------|---------------|
-|   0    | uint8  | Version       |
+|   1    | uint8  | Version       |
 |   32   | []byte | X25519 pubkey |
 
-The current version is 2.
+The current version is 3.
 
-The *accepting* peer derives the shared X25519 secret, hashes it with BLAKE2b
-for use as a ChaCha20-Poly1305 key, hashes that key *again* to derive the
-initial nonce value, and responds with:
+The *accepting* peer generates an X25519 keypair, derives the shared X25519
+secret, hashes it with BLAKE2b for use as a ChaCha20-Poly1305 key, hashes that
+key *again* to derive the initial nonce value, and responds with:
 
 | Length | Type   | Description        |
 |--------|--------|--------------------|
-|   0    | uint8  | Version            |
+|   1    | uint8  | Version            |
 |   32   | []byte | X25519 pubkey      |
 |   64   | []byte | Ed25519 signature  |
 |   24   |        | Encrypted settings |
@@ -60,7 +60,7 @@ The settings are:
 |   4    | uint32 | Max timeout | 120000-7200000 |
 
 Settings are encrypted in the same manner as [Packets](#packets): a ciphertext
-(8 bytes in this case) followed by a 16-byte tag.
+(8 bytes in this case) followed by a 16-byte authentication tag.
 
 Peers agree upon settings by choosing the minimum of the two packet sizes and
 the maximum of the two timeouts. The timeout is an integer number of
@@ -116,8 +116,9 @@ must not be split across packet boundaries. (In other words, the maximum size of
 a frame's payload is `n - (4 + 2 + 2)`.)
 
 A separate nonce is tracked for both the dialing and accepting peer, incremented
-after each use. The initial value for both nonces is the first 12 bytes of
-BLAKE2b(BLAKE2b(shared secret)). To increment a nonce, interpret its leading 8
+after each use. The initial value for the nonces is the first 12 bytes of
+BLAKE2b(BLAKE2b(shared secret)), but the most significant bit of the accepting
+peer's nonce is flipped. To increment a nonce, interpret its least-significant 8
 bytes as a 64-bit unsigned integer.
 
 ### Covert Frames

--- a/v2/mux.go
+++ b/v2/mux.go
@@ -383,8 +383,8 @@ func newMux(conn net.Conn, cipher *seqCipher, settings connSettings) *Mux {
 }
 
 // Dial initiates a mux protocol handshake on the provided conn.
-func Dial(conn net.Conn, theirKey ed25519.PublicKey) (*Mux, error) {
-	cipher, settings, err := initiateHandshake(conn, theirKey, defaultConnSettings)
+func Dial(conn net.Conn, theirKey ed25519.PublicKey, theirVersion uint8) (*Mux, error) {
+	cipher, settings, err := initiateHandshake(conn, theirKey, theirVersion, defaultConnSettings)
 	if err != nil {
 		return nil, fmt.Errorf("handshake failed: %w", err)
 	}
@@ -392,8 +392,8 @@ func Dial(conn net.Conn, theirKey ed25519.PublicKey) (*Mux, error) {
 }
 
 // Accept reciprocates a mux protocol handshake on the provided conn.
-func Accept(conn net.Conn, ourKey ed25519.PrivateKey) (*Mux, error) {
-	cipher, settings, err := acceptHandshake(conn, ourKey, defaultConnSettings)
+func Accept(conn net.Conn, ourKey ed25519.PrivateKey, theirVersion uint8) (*Mux, error) {
+	cipher, settings, err := acceptHandshake(conn, ourKey, theirVersion, defaultConnSettings)
 	if err != nil {
 		return nil, fmt.Errorf("handshake failed: %w", err)
 	}
@@ -408,12 +408,12 @@ var anonPubkey = anonPrivkey.Public().(ed25519.PublicKey)
 // DialAnonymous initiates a mux protocol handshake to a party without a
 // pre-established identity. The counterparty must reciprocate the handshake with
 // AcceptAnonymous.
-func DialAnonymous(conn net.Conn) (*Mux, error) { return Dial(conn, anonPubkey) }
+func DialAnonymous(conn net.Conn) (*Mux, error) { return Dial(conn, anonPubkey, 3) }
 
 // AcceptAnonymous reciprocates a mux protocol handshake without a
 // pre-established identity. The counterparty must initiate the handshake with
 // DialAnonymous.
-func AcceptAnonymous(conn net.Conn) (*Mux, error) { return Accept(conn, anonPrivkey) }
+func AcceptAnonymous(conn net.Conn) (*Mux, error) { return Accept(conn, anonPrivkey, 3) }
 
 // A Stream is a duplex connection multiplexed over a net.Conn. It implements
 // the net.Conn interface.

--- a/v2/mux_test.go
+++ b/v2/mux_test.go
@@ -87,7 +87,7 @@ func TestMux(t *testing.T) {
 			if err != nil {
 				return err
 			}
-			m, err := Accept(conn, serverKey)
+			m, err := Accept(conn, serverKey, 3)
 			if err != nil {
 				return err
 			}
@@ -111,7 +111,7 @@ func TestMux(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	m, err := Dial(conn, serverKey.Public().(ed25519.PublicKey))
+	m, err := Dial(conn, serverKey.Public().(ed25519.PublicKey), 3)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Sia has historically hashed all signature messages with BLAKE2b (in addition to the SHA512 performed internally by Ed25519), but this is unnecessary. Furthermore, nonces were being reused in an unsafe manner that could leak plaintext relationships (though the encryption key itself remains safe). This PR addresses both issues by bumping the version to 3 and branching on the version within the handshake. I don't love this; the "right" way to introduce a new version is to create an entire new `v3` package. But that felt like an egregious amount of duplicated code. I'm hoping that we can clean up this situation when we drop support for v1 post-hardfork.

I'll try running a node with these changes to ensure that it can communicate with existing v2 muxes.