### PR TITLE
v2: Add theirVersion parameter to Dial/AcceptAnonymous

### DIFF
--- a/v2/mux.go
+++ b/v2/mux.go
@@ -408,12 +408,16 @@ var anonPubkey = anonPrivkey.Public().(ed25519.PublicKey)
 // DialAnonymous initiates a mux protocol handshake to a party without a
 // pre-established identity. The counterparty must reciprocate the handshake with
 // AcceptAnonymous.
-func DialAnonymous(conn net.Conn) (*Mux, error) { return Dial(conn, anonPubkey, 3) }
+func DialAnonymous(conn net.Conn, theirVersion uint8) (*Mux, error) {
+	return Dial(conn, anonPubkey, theirVersion)
+}
 
 // AcceptAnonymous reciprocates a mux protocol handshake without a
 // pre-established identity. The counterparty must initiate the handshake with
 // DialAnonymous.
-func AcceptAnonymous(conn net.Conn) (*Mux, error) { return Accept(conn, anonPrivkey, 3) }
+func AcceptAnonymous(conn net.Conn, theirVersion uint8) (*Mux, error) {
+	return Accept(conn, anonPrivkey, theirVersion)
+}
 
 // A Stream is a duplex connection multiplexed over a net.Conn. It implements
 // the net.Conn interface.

--- a/v2/mux_test.go
+++ b/v2/mux_test.go
@@ -28,7 +28,7 @@ func newTestingPair(tb testing.TB) (dialed, accepted *Mux) {
 	go func() {
 		conn, err := l.Accept()
 		if err == nil {
-			accepted, err = AcceptAnonymous(conn)
+			accepted, err = AcceptAnonymous(conn, 3)
 		}
 		errChan <- err
 	}()
@@ -37,7 +37,7 @@ func newTestingPair(tb testing.TB) (dialed, accepted *Mux) {
 	if err != nil {
 		tb.Fatal(err)
 	}
-	dialed, err = DialAnonymous(conn)
+	dialed, err = DialAnonymous(conn, 3)
 	if err != nil {
 		tb.Fatal(err)
 	}
@@ -416,7 +416,7 @@ func TestCovertStream(t *testing.T) {
 			if err != nil {
 				return err
 			}
-			m, err := AcceptAnonymous(conn)
+			m, err := AcceptAnonymous(conn, 3)
 			if err != nil {
 				return err
 			}
@@ -468,7 +468,7 @@ func TestCovertStream(t *testing.T) {
 	}
 	conn = &statsConn{Conn: conn} // track raw number of bytes on wire
 
-	m, err := DialAnonymous(conn)
+	m, err := DialAnonymous(conn, 3)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -713,7 +713,7 @@ func BenchmarkCovertStream(b *testing.B) {
 			if err != nil {
 				return err
 			}
-			m, err := AcceptAnonymous(conn)
+			m, err := AcceptAnonymous(conn, 3)
 			if err != nil {
 				return err
 			}
@@ -754,7 +754,7 @@ func BenchmarkCovertStream(b *testing.B) {
 	if err != nil {
 		b.Fatal(err)
 	}
-	m, err := DialAnonymous(conn)
+	m, err := DialAnonymous(conn, 3)
 	if err != nil {
 		b.Fatal(err)
 	}


### PR DESCRIPTION
Follow up to #11 

btw, I started a local `walletd` node (@ master) and was able to connect to it using the new mux. I was also able to connect after switching `walletd` to the new mux. 👍🏻 