### PR TITLE
Fix close not notifying peer of closed stream when stream deadline is reached

### DIFF
--- a/.changeset/fix_close_failing_after_write_deadline_is_reached.md
+++ b/.changeset/fix_close_failing_after_write_deadline_is_reached.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# Fix Close failing after write deadline is reached.

--- a/.changeset/fix_goroutine_leak_in_readloop.md
+++ b/.changeset/fix_goroutine_leak_in_readloop.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# Fix goroutine leak in readLoop.

--- a/.changeset/update_go_version_to_v1260.md
+++ b/.changeset/update_go_version_to_v1260.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# Update Go version to v1.26.0.

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module go.sia.tech/mux
 
-go 1.25.0
-
-toolchain go1.25.5
+go 1.26.0
 
 require (
 	go.uber.org/goleak v1.3.0

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.25.0
 toolchain go1.25.5
 
 require (
+	go.uber.org/goleak v1.3.0
 	golang.org/x/crypto v0.49.0
 	lukechampine.com/frand v1.5.1
 )

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,16 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
+github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
+go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 golang.org/x/crypto v0.49.0 h1:+Ng2ULVvLHnJ/ZFEq4KdcDd/cfjrrjjNSXNzxg0Y4U4=
 golang.org/x/crypto v0.49.0/go.mod h1:ErX4dUh2UM+CFYiXZRTcMpEcN8b/1gxEuv3nODoYtCA=
 golang.org/x/sys v0.42.0 h1:omrd2nAlyT5ESRdCLYdm3+fMfNFE/+Rf4bDIQImRJeo=
 golang.org/x/sys v0.42.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 lukechampine.com/frand v1.5.1 h1:fg0eRtdmGFIxhP5zQJzM1lFDbD6CUfu/f+7WgAZd5/w=
 lukechampine.com/frand v1.5.1/go.mod h1:4VstaWc2plN4Mjr10chUD46RAVGWhpkZ5Nja8+Azp0Q=

--- a/v3/mux.go
+++ b/v3/mux.go
@@ -686,16 +686,24 @@ func (s *Stream) Close() error {
 		return nil
 	}
 	s.err = ErrClosedStream
+	established := s.established
 	s.readBuf = nil
 	s.cond.Broadcast()
 	s.cond.L.Unlock()
+
+	// if the stream was never established (no frames were sent to the peer),
+	// don't send a flagLast frame since the peer doesn't know about this stream
+	// and would treat it as an error.
+	if !established {
+		return nil
+	}
 
 	h := frameHeader{
 		id:    s.id,
 		flags: flagLast,
 	}
 
-	// Normally, we use s.wd as the deadline when sending frames, but in this
+	// normally, we use s.wd as the deadline when sending frames, but in this
 	// case, it's possible that we're closing because s.wd expired. So to
 	// prevent bufferFrame from failing immediately, we use an explicit
 	// deadline.

--- a/v3/mux.go
+++ b/v3/mux.go
@@ -665,6 +665,16 @@ func (s *Stream) Write(p []byte) (int, error) {
 
 // Close closes the Stream. The underlying connection is not closed.
 func (s *Stream) Close() error {
+	// always delete stream from Mux after closing it
+	defer func() {
+		s.m.mu.Lock()
+		delete(s.m.streams, s.id)
+		s.m.closingStreams[s.id] = closingStream{
+			closed: time.Now(),
+		}
+		s.m.mu.Unlock()
+	}()
+
 	// cancel outstanding Read/Write calls
 	//
 	// NOTE: Read calls will be interrupted immediately, but Write calls might
@@ -688,14 +698,6 @@ func (s *Stream) Close() error {
 	if err != nil && err != ErrPeerClosedStream {
 		return err
 	}
-
-	// delete stream from Mux
-	s.m.mu.Lock()
-	delete(s.m.streams, s.id)
-	s.m.closingStreams[s.id] = closingStream{
-		closed: time.Now(),
-	}
-	s.m.mu.Unlock()
 	return nil
 }
 

--- a/v3/mux.go
+++ b/v3/mux.go
@@ -675,7 +675,7 @@ func (s *Stream) Close() error {
 		id:    s.id,
 		flags: flagLast,
 	}
-	err := s.m.bufferFrame(h, nil, s.wd, s.covert)
+	err := s.m.bufferFrame(h, nil, time.Now().Add(30*time.Second), s.covert)
 	if err != nil && err != ErrPeerClosedStream {
 		return err
 	}

--- a/v3/mux.go
+++ b/v3/mux.go
@@ -694,7 +694,12 @@ func (s *Stream) Close() error {
 		id:    s.id,
 		flags: flagLast,
 	}
-	err := s.m.bufferFrame(h, nil, time.Now().Add(30*time.Second), s.covert)
+
+	// Normally, we use s.wd as the deadline when sending frames, but in this
+	// case, it's possible that we're closing because s.wd expired. So to
+	// prevent bufferFrame from failing immediately, we use an explicit
+	// deadline.
+	err := s.m.bufferFrame(h, nil, time.Now().Add(10*time.Second), s.covert)
 	if err != nil && err != ErrPeerClosedStream {
 		return err
 	}

--- a/v3/mux.go
+++ b/v3/mux.go
@@ -272,10 +272,19 @@ func (m *Mux) readLoop() {
 	var wg sync.WaitGroup
 	defer wg.Wait()
 	cleanupTicker := time.NewTicker(closingStreamCleanupInterval)
-	defer cleanupTicker.Stop()
+	cleanupDone := make(chan struct{})
+	defer func() {
+		cleanupTicker.Stop()
+		close(cleanupDone)
+	}()
 	wg.Go(func() {
-		for range cleanupTicker.C {
-			m.pruneClosedStreams()
+		for {
+			select {
+			case <-cleanupDone:
+				return
+			case <-cleanupTicker.C:
+				m.pruneClosedStreams()
+			}
 		}
 	})
 

--- a/v3/mux_test.go
+++ b/v3/mux_test.go
@@ -248,14 +248,14 @@ func TestDeadline(t *testing.T) {
 			s.SetDeadline(time.Now().Add(time.Hour)) // plenty of time
 		}},
 		{true, func(s *Stream) {
-			s.SetDeadline(time.Now().Add(time.Millisecond)) // too short
+			s.SetDeadline(time.Now()) // too short
 		}},
 		{true, func(s *Stream) {
-			s.SetDeadline(time.Now().Add(time.Millisecond))
+			s.SetDeadline(time.Now())
 			s.SetReadDeadline(time.Time{}) // Write should still fail
 		}},
 		{true, func(s *Stream) {
-			s.SetDeadline(time.Now().Add(time.Millisecond))
+			s.SetDeadline(time.Now())
 			s.SetWriteDeadline(time.Time{}) // Read should still fail
 		}},
 		{false, func(s *Stream) {
@@ -263,7 +263,7 @@ func TestDeadline(t *testing.T) {
 			s.SetDeadline(time.Time{}) // should overwrite
 		}},
 		{false, func(s *Stream) {
-			s.SetDeadline(time.Now().Add(time.Millisecond))
+			s.SetDeadline(time.Now())
 			s.SetWriteDeadline(time.Time{}) // overwrites Read
 			s.SetReadDeadline(time.Time{})  // overwrites Write
 		}},
@@ -272,6 +272,14 @@ func TestDeadline(t *testing.T) {
 		err := func() error {
 			s := m1.DialStream()
 			defer s.Close()
+			if _, err := s.Write([]byte{0}); err != nil {
+				// establish stream before setting deadlines to avoid the server
+				// getting an "received packet for unknown stream" error. That
+				// happens when the first write fails due to the timeout and
+				// then Close sending the final frame that isn't known to the
+				// peer.
+				return err
+			}
 			test.fn(s) // set deadlines
 
 			// need to write a fairly large message; otherwise the packets just

--- a/v3/mux_test.go
+++ b/v3/mux_test.go
@@ -15,9 +15,14 @@ import (
 	"testing"
 	"time"
 
+	"go.uber.org/goleak"
 	"golang.org/x/crypto/chacha20poly1305"
 	"lukechampine.com/frand"
 )
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}
 
 func newTestingPair(tb testing.TB) (dialed, accepted *Mux) {
 	l, err := net.Listen("tcp", ":0")
@@ -59,13 +64,19 @@ func handleStreams(m *Mux, fn func(*Stream) error) chan error {
 		for {
 			s, err := m.AcceptStream()
 			if err != nil {
-				errChan <- err
+				select {
+				case errChan <- err:
+				default:
+				}
 				return
 			}
 			go func() {
 				defer s.Close()
 				if err := fn(s); err != nil {
-					errChan <- err
+					select {
+					case errChan <- err:
+					default:
+					}
 					return
 				}
 			}()

--- a/v3/mux_test.go
+++ b/v3/mux_test.go
@@ -829,6 +829,58 @@ func BenchmarkCovertStream(b *testing.B) {
 	b.ReportMetric(float64(b.N)/time.Since(start).Seconds(), "frames/sec")
 }
 
+func TestCloseAfterTimeout(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+
+	m1, m2 := newTestingPair(t)
+
+	// on the server side, block on Read until the stream is closed
+	serverDone := make(chan error, 1)
+	_ = handleStreams(m2, func(s *Stream) error {
+		_, err := io.Copy(io.Discard, s)
+		serverDone <- err
+		return err
+	})
+
+	s := m1.DialStream()
+
+	// establish the stream with an initial write so the peer is aware of it
+	if _, err := s.Write([]byte("established")); err != nil {
+		t.Fatal(err)
+	}
+
+	// set a very short timeout and sleep past it
+	s.SetDeadline(time.Now().Add(time.Millisecond))
+	time.Sleep(10 * time.Millisecond)
+
+	// write should fail with a timeout error
+	_, err := s.Write([]byte("hello"))
+	if !errors.Is(err, os.ErrDeadlineExceeded) {
+		t.Fatalf("expected deadline exceeded error, got %v", err)
+	}
+
+	// Close should still succeed after a timeout
+	if err := s.Close(); err != nil {
+		t.Fatal("expected Close to succeed, got", err)
+	}
+
+	// the server side should be unblocked
+	select {
+	case err := <-serverDone:
+		if err != nil {
+			t.Fatal("expected peer closed stream error on server side without an error, got", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("server side was not unblocked after Close")
+	}
+
+	if err := m1.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func BenchmarkPackets(b *testing.B) {
 	for _, packetSize := range []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 20} {
 		b.Run(fmt.Sprintf("%dx%d", ipv6MTU, packetSize), func(b *testing.B) {


### PR DESCRIPTION
The usual pattern for renters is

1. open stream
2. set deadline
3. close stream (deferred)

However, right now closing the stream will not actually notify the host of the stream being closed. Which can be observed in the host logs in the form of 10 minute timeouts on streams. Which can lead to pretty awkward chain reactions after the first timeout. 

This PR fixes this by not using the regular write deadline in `Close`.
Result of regression test: https://github.com/SiaFoundation/mux/actions/runs/23431757446/job/68159607015?pr=35
This also required adjusting `TestDeadline` which seems to have relied on `Close` returning the timeout error rather than the actual write.

NOTE: after running the indexer test suite I also noticed that the mux leaks goroutines so I fixed that leak in this PR as well.