### PR TITLE
Fix Close() deadlock

### DIFF
--- a/.changeset/fix_close_hanging_on_tcp_backpressure.md
+++ b/.changeset/fix_close_hanging_on_tcp_backpressure.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# Fix Close hanging indefinitely when conn.Write is blocked due to TCP backpressure

--- a/.changeset/fix_close_hanging_on_tcp_backpressure.md
+++ b/.changeset/fix_close_hanging_on_tcp_backpressure.md
@@ -4,5 +4,4 @@ default: patch
 
 # Fix Close hanging indefinitely when conn.Write is blocked due to TCP backpressure
 
-Close now waits at most 5 seconds for pending writes to flush before tearing
-down the connection.
+Close no longer attempts to flush the write buffer and closes the underlying connectino immediately.

--- a/.changeset/fix_close_hanging_on_tcp_backpressure.md
+++ b/.changeset/fix_close_hanging_on_tcp_backpressure.md
@@ -4,4 +4,4 @@ default: patch
 
 # Fix Close hanging indefinitely when conn.Write is blocked due to TCP backpressure
 
-Close no longer attempts to flush the write buffer and closes the underlying connectino immediately.
+Close no longer attempts to flush the write buffer and closes the underlying connection immediately.

--- a/.changeset/fix_close_hanging_on_tcp_backpressure.md
+++ b/.changeset/fix_close_hanging_on_tcp_backpressure.md
@@ -3,3 +3,6 @@ default: patch
 ---
 
 # Fix Close hanging indefinitely when conn.Write is blocked due to TCP backpressure
+
+Close now waits at most 5 seconds for pending writes to flush before tearing
+down the connection.

--- a/v3/mux.go
+++ b/v3/mux.go
@@ -359,7 +359,8 @@ func (m *Mux) readLoop() {
 	}
 }
 
-// Close closes the underlying net.Conn.
+// Close waits up to 5 seconds for pending writes to flush, then closes the
+// underlying net.Conn.
 func (m *Mux) Close() error {
 	// wait briefly for pending writes to flush before tearing down
 	m.mu.Lock()

--- a/v3/mux.go
+++ b/v3/mux.go
@@ -47,10 +47,6 @@ const (
 	// maxKeepalives is the maximum number of consecutive keepalives to send
 	// without any other traffic before closing the mux.
 	maxKeepalives = 4
-
-	// closeFlushTimeout is the maximum time Close will wait for pending
-	// writes to be flushed before tearing down the connection.
-	closeFlushTimeout = 5 * time.Second
 )
 
 // A Mux multiplexes multiple duplex Streams onto a single net.Conn.
@@ -359,19 +355,8 @@ func (m *Mux) readLoop() {
 	}
 }
 
-// Close waits up to 5 seconds for pending writes to flush, then closes the
-// underlying net.Conn.
+// Close closes the underlying net.Conn.
 func (m *Mux) Close() error {
-	// wait briefly for pending writes to flush before tearing down
-	m.mu.Lock()
-	deadline := time.Now().Add(closeFlushTimeout)
-	timer := time.AfterFunc(closeFlushTimeout, m.bufferCond.Broadcast)
-	for len(m.writeBuf) != 0 && m.err == nil && time.Now().Before(deadline) {
-		m.bufferCond.Wait()
-	}
-	timer.Stop()
-	m.mu.Unlock()
-
 	err := m.setErr(ErrClosedConn)
 	if err == ErrClosedConn || err == ErrPeerClosedConn {
 		err = nil

--- a/v3/mux.go
+++ b/v3/mux.go
@@ -47,6 +47,10 @@ const (
 	// maxKeepalives is the maximum number of consecutive keepalives to send
 	// without any other traffic before closing the mux.
 	maxKeepalives = 4
+
+	// closeFlushTimeout is the maximum time Close will wait for pending
+	// writes to be flushed before tearing down the connection.
+	closeFlushTimeout = 5 * time.Second
 )
 
 // A Mux multiplexes multiple duplex Streams onto a single net.Conn.
@@ -357,12 +361,16 @@ func (m *Mux) readLoop() {
 
 // Close closes the underlying net.Conn.
 func (m *Mux) Close() error {
-	// if there's a buffered Write, wait for it to be sent
+	// wait briefly for pending writes to flush before tearing down
 	m.mu.Lock()
-	for len(m.writeBuf) != 0 && m.err == nil {
+	deadline := time.Now().Add(closeFlushTimeout)
+	timer := time.AfterFunc(closeFlushTimeout, m.bufferCond.Broadcast)
+	for len(m.writeBuf) != 0 && m.err == nil && time.Now().Before(deadline) {
 		m.bufferCond.Wait()
 	}
+	timer.Stop()
 	m.mu.Unlock()
+
 	err := m.setErr(ErrClosedConn)
 	if err == ErrClosedConn || err == ErrPeerClosedConn {
 		err = nil

--- a/v3/mux_test.go
+++ b/v3/mux_test.go
@@ -160,6 +160,7 @@ func TestMux(t *testing.T) {
 			} else if _, err := fmt.Fprintf(s, "hello, %s!", buf[:n]); err != nil {
 				return err
 			}
+			io.Copy(io.Discard, s) // blocks until the client closes, ensuring we can read what the server wrote before the mux is closed
 			return s.Close()
 		}()
 	}()
@@ -624,7 +625,6 @@ func TestWriteAfterStreamClose(t *testing.T) {
 		} else if _, err := s.Write(buf[:n]); err != nil {
 			return err
 		}
-		t.Log("handler finished")
 		return nil
 	})
 
@@ -1014,7 +1014,7 @@ func TestCloseWithBlockedWrite(t *testing.T) {
 	// refill writeBuf while writeLoop is stuck
 	s.Write(make([]byte, m1.settings.maxPayloadSize()))
 
-	// assert Close returns
+	// assert Close returns immediately
 	closeDone := make(chan error, 1)
 	go func() {
 		closeDone <- m1.Close()
@@ -1025,7 +1025,7 @@ func TestCloseWithBlockedWrite(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-	case <-time.After(closeFlushTimeout + time.Second):
-		t.Fatal("Mux.Close() hung; deadlocked waiting for writeBuf to drain")
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("Close() did not return immediately")
 	}
 }

--- a/v3/mux_test.go
+++ b/v3/mux_test.go
@@ -521,9 +521,8 @@ func TestCovertStream(t *testing.T) {
 			}
 			if _, err := fmt.Fprintf(s, "hello, %s!", buf[:n]); err != nil {
 				return err
-			} else if err := s.Close(); err != nil {
-				return err
 			}
+			io.Copy(io.Discard, s) // wait for the client to finish reading before tearing down
 			return m.Close()
 		}()
 	}()

--- a/v3/mux_test.go
+++ b/v3/mux_test.go
@@ -487,42 +487,54 @@ func TestCovertStream(t *testing.T) {
 				return err
 			}
 			defer m.Close()
-			// accept covert stream
-			cs, err := m.AcceptStream()
-			if err != nil {
-				return err
-			}
-			covertCh := make(chan error)
-			go func() {
-				defer cs.Close()
-				buf := make([]byte, 100)
-				if n, err := cs.Read(buf); err != nil {
-					covertCh <- err
-				} else if _, err := fmt.Fprintf(cs, "hello, %s!", buf[:n]); err != nil {
-					covertCh <- err
-				} else {
-					covertCh <- cs.Close()
-				}
-			}()
-			// accept regular stream
+			// regular stream arrives first since covert data is in the padding
 			s, err := m.AcceptStream()
 			if err != nil {
 				return err
 			}
 			defer s.Close()
-			buf := make([]byte, 100)
-			n, err := s.Read(buf)
+
+			// read s in a goroutine to unblock the readLoop for the covert frame
+			type readRes struct {
+				data []byte
+				err  error
+			}
+			readChan := make(chan readRes, 1)
+			go func() {
+				buf := make([]byte, 100)
+				n, err := s.Read(buf)
+				readChan <- readRes{buf[:n], err}
+			}()
+
+			// accept covert stream
+			cs, err := m.AcceptStream()
 			if err != nil {
 				return err
 			}
-			// wait for covert stream to buffer before writing
-			if err := <-covertCh; err != nil {
+			defer cs.Close()
+
+			// respond to covert stream
+			buf := make([]byte, 100)
+			n, err := cs.Read(buf)
+			if err != nil {
 				return err
 			}
-			if _, err := fmt.Fprintf(s, "hello, %s!", buf[:n]); err != nil {
+			if _, err := fmt.Fprintf(cs, "hello, %s!", buf[:n]); err != nil {
 				return err
 			}
-			io.Copy(io.Discard, s) // wait for the client to finish reading before tearing down
+			if err := cs.Close(); err != nil {
+				return err
+			}
+
+			// respond to regular stream
+			res := <-readChan
+			if res.err != nil {
+				return res.err
+			}
+			if _, err := fmt.Fprintf(s, "hello, %s!", res.data); err != nil {
+				return err
+			}
+			io.Copy(io.Discard, s) // wait for client to close
 			return m.Close()
 		}()
 	}()

--- a/v3/mux_test.go
+++ b/v3/mux_test.go
@@ -1012,8 +1012,7 @@ func TestCloseWithBlockedWrite(t *testing.T) {
 	}
 
 	// refill writeBuf while writeLoop is stuck
-	go s.Write(make([]byte, m1.settings.maxPayloadSize()))
-	time.Sleep(50 * time.Millisecond)
+	s.Write(make([]byte, m1.settings.maxPayloadSize()))
 
 	// assert Close returns
 	closeDone := make(chan error, 1)

--- a/v3/mux_test.go
+++ b/v3/mux_test.go
@@ -25,6 +25,11 @@ func TestMain(m *testing.M) {
 }
 
 func newTestingPair(tb testing.TB) (dialed, accepted *Mux) {
+	dialed, accepted = newTestingPairCustom(tb, nil)
+	return
+}
+
+func newTestingPairCustom(tb testing.TB, wrapConn func(net.Conn) net.Conn) (dialed, accepted *Mux) {
 	l, err := net.Listen("tcp", ":0")
 	if err != nil {
 		tb.Fatal(err)
@@ -41,6 +46,9 @@ func newTestingPair(tb testing.TB) (dialed, accepted *Mux) {
 	conn, err := net.Dial("tcp", l.Addr().String())
 	if err != nil {
 		tb.Fatal(err)
+	}
+	if wrapConn != nil {
+		conn = wrapConn(conn)
 	}
 	dialed, err = DialAnonymous(conn)
 	if err != nil {
@@ -83,6 +91,44 @@ func handleStreams(m *Mux, fn func(*Stream) error) chan error {
 		}
 	}()
 	return errChan
+}
+
+// blockConn simulates TCP backpressure by blocking writes on demand
+type blockConn struct {
+	net.Conn
+
+	closeOnce sync.Once
+	blockCh   chan struct{} // close to make writes block
+	blockedCh chan struct{} // signaled when a write is waiting
+	closeCh   chan struct{} // closed by Close to release blocked writes
+}
+
+func newBlockConn(c net.Conn) *blockConn {
+	return &blockConn{
+		Conn:      c,
+		blockCh:   make(chan struct{}),
+		blockedCh: make(chan struct{}, 1),
+		closeCh:   make(chan struct{}),
+	}
+}
+
+func (c *blockConn) Write(b []byte) (int, error) {
+	select {
+	case <-c.blockCh:
+		select {
+		case c.blockedCh <- struct{}{}:
+		default:
+		}
+		<-c.closeCh
+		return 0, net.ErrClosed
+	default:
+		return c.Conn.Write(b)
+	}
+}
+
+func (c *blockConn) Close() error {
+	c.closeOnce.Do(func() { close(c.closeCh) })
+	return c.Conn.Close()
 }
 
 func TestMux(t *testing.T) {
@@ -926,5 +972,61 @@ func BenchmarkPackets(b *testing.B) {
 				}
 			}
 		})
+	}
+}
+
+// TestCloseWithBlockedWrite is a regression test for a deadlock in Close()
+// where we would be stuck waiting for writeBuf to drain, which never happens
+// because the writeLoop might block on conn.Write due to TCP backpressure
+func TestCloseWithBlockedWrite(t *testing.T) {
+	var bc *blockConn
+	m1, m2 := newTestingPairCustom(t, func(conn net.Conn) net.Conn {
+		bc = newBlockConn(conn)
+		return bc
+	})
+	defer bc.Close() // unblock writes so cleanup doesn't hang
+
+	handleStreams(m2, func(s *Stream) error {
+		io.Copy(io.Discard, s)
+		return nil
+	})
+
+	// establish stream
+	s := m1.DialStream()
+	if _, err := s.Write([]byte("hello")); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(50 * time.Millisecond)
+
+	// block writes
+	close(bc.blockCh)
+
+	// trigger writeLoop to block on conn.Write
+	go s.Write(make([]byte, m1.settings.maxPayloadSize()))
+
+	// wait for writeLoop to block
+	select {
+	case <-bc.blockedCh:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for conn.Write to block")
+	}
+
+	// refill writeBuf while writeLoop is stuck
+	go s.Write(make([]byte, m1.settings.maxPayloadSize()))
+	time.Sleep(50 * time.Millisecond)
+
+	// assert Close returns
+	closeDone := make(chan error, 1)
+	go func() {
+		closeDone <- m1.Close()
+	}()
+
+	select {
+	case err := <-closeDone:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(closeFlushTimeout + time.Second):
+		t.Fatal("Mux.Close() hung; deadlocked waiting for writeBuf to drain")
 	}
 }


### PR DESCRIPTION
This PR updates `Close` to no longer attempt to flush the write buffer.. A severely congested host can cause conn.Write to block, which prevents writeBuf from draining, hanging Close() forever.

This is in reference of this [bug report](https://discord.com/channels/809849352516141067/946328563320238190/1501247626484519033) on Discord. I opened a [PR on `renterd`](https://github.com/SiaFoundation/renterd/pull/2059) to make sure the pool's lock never deadlocks because we fail to quickly close a transport.