### PR TITLE
Fix race between Write and Close

### DIFF
--- a/.changeset/prevent_streamwrite_from_sending_a_frame_on_an_already_closed_stream.md
+++ b/.changeset/prevent_streamwrite_from_sending_a_frame_on_an_already_closed_stream.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# Prevent Stream.Write from sending a frame on an already closed Stream.

--- a/v3/mux.go
+++ b/v3/mux.go
@@ -719,7 +719,7 @@ func (s *Stream) Close() error {
 	// prevent bufferFrame from failing immediately, we use an explicit
 	// deadline.
 	err := s.m.bufferFrame(s, h, nil, time.Now().Add(10*time.Second), s.covert)
-	if err != nil && err != ErrPeerClosedStream {
+	if err != nil && err != ErrPeerClosedStream && err != ErrClosedStream {
 		return err
 	}
 	return nil

--- a/v3/mux.go
+++ b/v3/mux.go
@@ -107,9 +107,12 @@ func (m *Mux) setErr(err error) error {
 }
 
 // bufferFrame blocks until it can store its frame in m.writeBuf (or, for covert
-// streams, m.covertBuf). It returns early with an error if m.err is set or if
-// the deadline expires.
-func (m *Mux) bufferFrame(h frameHeader, payload []byte, deadline time.Time, covert bool) error {
+// streams, m.covertBuf). It returns early with an error if m.err is set, if
+// s.err is set (unless the frame itself is flagLast), or if the deadline
+// expires. Re-checking s.err under m.mu is what guarantees that once Close
+// has queued its flagLast frame, no further frames for the same stream can
+// be queued behind it.
+func (m *Mux) bufferFrame(s *Stream, h frameHeader, payload []byte, deadline time.Time, covert bool) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if !deadline.IsZero() {
@@ -134,6 +137,19 @@ func (m *Mux) bufferFrame(h frameHeader, payload []byte, deadline time.Time, cov
 	} else if !deadline.IsZero() && !time.Now().Before(deadline) {
 		return os.ErrDeadlineExceeded
 	}
+
+	// if this is a normal frame, check for stream error. Upon Close, the
+	// stream's error is set to ErrClosedStream. After that, the only frame that
+	// we allow to be sent is a flagLast frame.
+	if h.flags&flagLast == 0 {
+		s.cond.L.Lock()
+		sErr := s.err
+		s.cond.L.Unlock()
+		if sErr != nil {
+			return sErr
+		}
+	}
+
 	// queue our frame and wake the writeLoop
 	//
 	// NOTE: it is not necessary to wait for the writeLoop to flush our frame.
@@ -650,7 +666,7 @@ func (s *Stream) Write(p []byte) (int, error) {
 			length: uint16(len(payload)),
 			flags:  flags,
 		}
-		err = s.m.bufferFrame(h, payload, s.wd, s.covert)
+		err = s.m.bufferFrame(s, h, payload, s.wd, s.covert)
 		if err != nil {
 			return len(p) - buf.Len(), err
 		}
@@ -702,7 +718,7 @@ func (s *Stream) Close() error {
 	// case, it's possible that we're closing because s.wd expired. So to
 	// prevent bufferFrame from failing immediately, we use an explicit
 	// deadline.
-	err := s.m.bufferFrame(h, nil, time.Now().Add(10*time.Second), s.covert)
+	err := s.m.bufferFrame(s, h, nil, time.Now().Add(10*time.Second), s.covert)
 	if err != nil && err != ErrPeerClosedStream {
 		return err
 	}

--- a/v3/mux.go
+++ b/v3/mux.go
@@ -146,6 +146,9 @@ func (m *Mux) bufferFrame(s *Stream, h frameHeader, payload []byte, deadline tim
 		sErr := s.err
 		s.cond.L.Unlock()
 		if sErr != nil {
+			// we aren't appending, so we wake up the next bufferFrame call
+			// which might be able to append to the buffer now.
+			m.bufferCond.Signal()
 			return sErr
 		}
 	}

--- a/v3/mux.go
+++ b/v3/mux.go
@@ -140,17 +140,22 @@ func (m *Mux) bufferFrame(s *Stream, h frameHeader, payload []byte, deadline tim
 
 	// if this is a normal frame, check for stream error. Upon Close, the
 	// stream's error is set to ErrClosedStream. After that, the only frame that
-	// we allow to be sent is a flagLast frame.
+	// we allow to be sent is a flagLast frame. For flagFirst, also set
+	// s.established under the same lock, otherwise a racing Close can skip
+	// flagLast and leave the peer with a phantom stream.
 	if h.flags&flagLast == 0 {
 		s.cond.L.Lock()
-		sErr := s.err
-		s.cond.L.Unlock()
-		if sErr != nil {
+		if s.err != nil {
+			s.cond.L.Unlock()
 			// we aren't appending, so we wake up the next bufferFrame call
 			// which might be able to append to the buffer now.
 			m.bufferCond.Signal()
-			return sErr
+			return s.err
 		}
+		if h.flags&flagFirst != 0 {
+			s.established = true
+		}
+		s.cond.L.Unlock()
 	}
 
 	// queue our frame and wake the writeLoop
@@ -671,14 +676,6 @@ func (s *Stream) Write(p []byte) (int, error) {
 		err = s.m.bufferFrame(s, h, payload, s.wd, s.covert)
 		if err != nil {
 			return len(p) - buf.Len(), err
-		}
-		// only mark the stream as established after the flagFirst frame has
-		// been successfully queued, otherwise a later Close could send a
-		// flagLast frame for a stream the peer never learned about.
-		if flags&flagFirst != 0 {
-			s.cond.L.Lock()
-			s.established = true
-			s.cond.L.Unlock()
 		}
 	}
 	return len(p), nil

--- a/v3/mux.go
+++ b/v3/mux.go
@@ -656,7 +656,6 @@ func (s *Stream) Write(p []byte) (int, error) {
 		var flags uint16
 		if err == nil && !s.established {
 			flags = flagFirst
-			s.established = true
 		}
 		s.cond.L.Unlock()
 		if err != nil {
@@ -672,6 +671,14 @@ func (s *Stream) Write(p []byte) (int, error) {
 		err = s.m.bufferFrame(s, h, payload, s.wd, s.covert)
 		if err != nil {
 			return len(p) - buf.Len(), err
+		}
+		// only mark the stream as established after the flagFirst frame has
+		// been successfully queued, otherwise a later Close could send a
+		// flagLast frame for a stream the peer never learned about.
+		if flags&flagFirst != 0 {
+			s.cond.L.Lock()
+			s.established = true
+			s.cond.L.Unlock()
 		}
 	}
 	return len(p), nil

--- a/v3/mux_test.go
+++ b/v3/mux_test.go
@@ -703,6 +703,85 @@ func TestWriteAfterStreamClose(t *testing.T) {
 	}
 }
 
+// TestCloseUnestablishedStream ensures that closing a Stream that was dialed
+// but never written to does not send a flagLast frame to the peer, which would
+// cause the peer mux to close with ErrUnknownStream.
+func TestCloseUnestablishedStream(t *testing.T) {
+	m1, m2 := newTestingPair(t)
+
+	serverCh := handleStreams(m2, func(s *Stream) error {
+		io.Copy(io.Discard, s)
+		return nil
+	})
+
+	if err := m1.DialStream().Close(); err != nil {
+		t.Fatalf("Close failed: %v", err)
+	}
+
+	// no frames should have been sent to the peer
+	select {
+	case err := <-serverCh:
+		t.Fatalf("m2 closed unexpectedly: %v", err)
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	if err := m1.Close(); err != nil {
+		t.Fatal(err)
+	} else if err := <-serverCh; err != nil && err != ErrPeerClosedConn {
+		t.Fatal(err)
+	}
+}
+
+// TestCloseUnestablishedStreamRace ensures that racing Write and Close on a
+// freshly-dialed Stream never leaves the peer with an orphaned stream: either
+// no frames are sent at all, or both flagFirst and flagLast are sent.
+func TestCloseUnestablishedStreamRace(t *testing.T) {
+	m1, m2 := newTestingPair(t)
+
+	serverCh := handleStreams(m2, func(s *Stream) error {
+		io.Copy(io.Discard, s)
+		return nil
+	})
+
+	const attempts = 500
+	for i := range attempts {
+		s := m1.DialStream()
+		var wg sync.WaitGroup
+		wg.Go(func() { s.Write([]byte("x")) })
+		wg.Go(func() { s.Close() })
+		wg.Wait()
+
+		select {
+		case err := <-serverCh:
+			t.Fatalf("attempt %d: m2 closed unexpectedly: %v", i, err)
+		default:
+		}
+	}
+
+	// any stream the peer accepted must have also received flagLast;
+	// otherwise it stays in m2.streams with a blocked io.Copy goroutine.
+	leaked := -1
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		m2.mu.Lock()
+		leaked = len(m2.streams)
+		m2.mu.Unlock()
+		if leaked == 0 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if leaked != 0 {
+		t.Fatalf("m2 has %d orphaned streams (Write/Close race left flagFirst without flagLast)", leaked)
+	}
+
+	if err := m1.Close(); err != nil {
+		t.Fatal(err)
+	} else if err := <-serverCh; err != nil && err != ErrPeerClosedConn {
+		t.Fatal(err)
+	}
+}
+
 // TestCloseWriteRace ensures that concurrently calling Write and Close on the
 // same Stream never causes the peer mux to close with ErrUnknownStream.
 func TestCloseWriteRace(t *testing.T) {

--- a/v3/mux_test.go
+++ b/v3/mux_test.go
@@ -708,7 +708,7 @@ func TestWriteAfterStreamClose(t *testing.T) {
 func TestCloseWriteRace(t *testing.T) {
 	m1, m2 := newTestingPair(t)
 
-	// Surface m2's mux-level error as soon as it occurs.
+	// surface m2's mux-level error as soon as it occurs.
 	m2Err := make(chan error, 1)
 	var wg sync.WaitGroup
 	wg.Go(func() {

--- a/v3/mux_test.go
+++ b/v3/mux_test.go
@@ -703,13 +703,8 @@ func TestWriteAfterStreamClose(t *testing.T) {
 	}
 }
 
-// TestCloseWriteRace exercises the race acknowledged by Stream.Close: a
-// concurrent Write that has already passed Close's s.err check can buffer a
-// data frame after the flagLast frame, which the peer's readLoop currently
-// rejects with ErrUnknownStream. The test repeatedly runs Write and Close in
-// parallel and fails if the peer ever surfaces ErrUnknownStream. After the
-// race is fixed (e.g. by tracking peer-closed streams in closingStreams), the
-// test should pass.
+// TestCloseWriteRace ensures that concurrently calling Write and Close on the
+// same Stream never causes the peer mux to close with ErrUnknownStream.
 func TestCloseWriteRace(t *testing.T) {
 	m1, m2 := newTestingPair(t)
 
@@ -754,13 +749,10 @@ func TestCloseWriteRace(t *testing.T) {
 		// simultaneously write and close the stream. Simulating a stream that
 		// gets interrupted by a close.
 		var wg sync.WaitGroup
-		wg.Add(2)
 		wg.Go(func() {
-			defer wg.Done()
 			s.Write(make([]byte, 1<<16))
 		})
 		wg.Go(func() {
-			defer wg.Done()
 			s.Close()
 		})
 		wg.Wait()

--- a/v3/mux_test.go
+++ b/v3/mux_test.go
@@ -703,6 +703,81 @@ func TestWriteAfterStreamClose(t *testing.T) {
 	}
 }
 
+// TestCloseWriteRace exercises the race acknowledged by Stream.Close: a
+// concurrent Write that has already passed Close's s.err check can buffer a
+// data frame after the flagLast frame, which the peer's readLoop currently
+// rejects with ErrUnknownStream. The test repeatedly runs Write and Close in
+// parallel and fails if the peer ever surfaces ErrUnknownStream. After the
+// race is fixed (e.g. by tracking peer-closed streams in closingStreams), the
+// test should pass.
+func TestCloseWriteRace(t *testing.T) {
+	m1, m2 := newTestingPair(t)
+
+	// Surface m2's mux-level error as soon as it occurs.
+	m2Err := make(chan error, 1)
+	var wg sync.WaitGroup
+	wg.Go(func() {
+		for {
+			s, err := m2.AcceptStream()
+			if err != nil {
+				select {
+				case m2Err <- err:
+				default:
+				}
+				return
+			}
+			wg.Go(func() {
+				io.Copy(io.Discard, s)
+				s.Close()
+			})
+		}
+	})
+
+	const attempts = 500
+	for i := range attempts {
+		// check if failure has already occurred
+		select {
+		case err := <-m2Err:
+			if errors.Is(err, ErrUnknownStream) {
+				t.Fatalf("attempt %d: m2 closed with ErrUnknownStream (Write/Close race reproduced)", i)
+			}
+			t.Fatalf("attempt %d: m2 closed unexpectedly: %v", i, err)
+		default:
+		}
+
+		// establish a stream by dialing it and writing a byte
+		s := m1.DialStream()
+		if _, err := s.Write([]byte("x")); err != nil {
+			t.Fatalf("attempt %d: establishing Write failed: %v", i, err)
+		}
+
+		// simultaneously write and close the stream. Simulating a stream that
+		// gets interrupted by a close.
+		var wg sync.WaitGroup
+		wg.Add(2)
+		wg.Go(func() {
+			defer wg.Done()
+			s.Write(make([]byte, 1<<16))
+		})
+		wg.Go(func() {
+			defer wg.Done()
+			s.Close()
+		})
+		wg.Wait()
+	}
+
+	// no ErrUnknownStream errors should have been observed
+	select {
+	case err := <-m2Err:
+		if errors.Is(err, ErrUnknownStream) {
+			t.Fatal("m2 closed with ErrUnknownStream (Write/Close race reproduced)")
+		}
+		t.Fatalf("m2 closed unexpectedly: %v", err)
+	case <-time.After(200 * time.Millisecond):
+	}
+	wg.Wait()
+}
+
 func TestKeepaliveTimeout(t *testing.T) {
 	settings := connSettings{
 		PacketSize: 1220,

--- a/v3/mux_test.go
+++ b/v3/mux_test.go
@@ -775,6 +775,8 @@ func TestCloseWriteRace(t *testing.T) {
 		t.Fatalf("m2 closed unexpectedly: %v", err)
 	case <-time.After(200 * time.Millisecond):
 	}
+
+	m1.Close()
 	wg.Wait()
 }
 


### PR DESCRIPTION
Something we observe in production is the host closing the mux because it receives a frame for an unknown stream. 
It seems like this is caused by a race between `Write` and `Close` where it is possible for `Write` to queue a frame after `Close` queues the final one. 