### PR TITLE
Don't register new streams after the mux has shut down

### DIFF
--- a/.changeset/short_circuits_readloop_if_an_error_occurs_before_stream_creation.md
+++ b/.changeset/short_circuits_readloop_if_an_error_occurs_before_stream_creation.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# Short-circuits readLoop if an error occurs before Stream creation

--- a/v3/mux.go
+++ b/v3/mux.go
@@ -363,6 +363,11 @@ func (m *Mux) readLoop() {
 				m.setErr(fmt.Errorf("exceeded concurrent stream limit (%v streams)", maxStreams))
 				return
 			}
+			// If the mux is already dying, do not register a new stream.
+			if m.err != nil {
+				m.mu.Unlock()
+				return
+			}
 			stream = &Stream{
 				m:           m,
 				id:          h.id,

--- a/v3/mux_test.go
+++ b/v3/mux_test.go
@@ -1230,3 +1230,35 @@ func TestCloseWithBlockedWrite(t *testing.T) {
 		t.Fatal("Close() did not return immediately")
 	}
 }
+
+// TestNewStreamDuringShutdown checks that opening streams while the mux
+// is being torn down does not leak any goroutines. If readLoop creates a
+// stream after the mux has entered its error state, nothing will ever wake
+// that stream's consumeFrame and the readLoop goroutine parks forever.
+func TestNewStreamDuringShutdown(t *testing.T) {
+	const (
+		iterations     = 200
+		streamsPerConn = 256
+	)
+	payload := make([]byte, 16) // a flagFirst frame carrying a 16-byte specifier
+
+	for i := 0; i < iterations; i++ {
+		dialed, accepted := newTestingPair(t)
+
+		// fire new-stream frames without reading or closing them, so that a
+		// stream raced past setErr parks in consumeFrame with a full readBuf.
+		for j := 0; j < streamsPerConn; j++ {
+			s := dialed.DialStream()
+			s.SetDeadline(time.Now().Add(time.Second))
+			if _, err := s.Write(payload); err != nil {
+				break
+			}
+		}
+
+		// let the frames reach the server, then tear the mux down while
+		// readLoop is still creating streams from them.
+		time.Sleep(time.Millisecond)
+		accepted.Close()
+		dialed.Close()
+	}
+}

--- a/v3/mux_test.go
+++ b/v3/mux_test.go
@@ -1242,12 +1242,12 @@ func TestNewStreamDuringShutdown(t *testing.T) {
 	)
 	payload := make([]byte, 16) // a flagFirst frame carrying a 16-byte specifier
 
-	for i := 0; i < iterations; i++ {
+	for range iterations {
 		dialed, accepted := newTestingPair(t)
 
 		// fire new-stream frames without reading or closing them, so that a
 		// stream raced past setErr parks in consumeFrame with a full readBuf.
-		for j := 0; j < streamsPerConn; j++ {
+		for range streamsPerConn {
 			s := dialed.DialStream()
 			s.SetDeadline(time.Now().Add(time.Second))
 			if _, err := s.Write(payload); err != nil {


### PR DESCRIPTION
Short-circuits readLoop if an error occurs before Stream creation